### PR TITLE
Improve go installation

### DIFF
--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -75,12 +75,11 @@ $(GOCC):
 	mkdir -p $(GOROOT)
 	curl -L $(GOURL)/$(GOPKG) | tar -C $(GOROOT) --strip 1 -xz
 
-selflink-stamp:
-	mkdir -p $(GOPATH)/src/github.com/prometheus
-	ln -s $(CURDIR) $(SELFLINK)
-	touch $@
+$(SELFLINK):
+	mkdir -p $(dir $@)
+	ln -s $(CURDIR) $@
 
-dependencies-stamp: $(SRC) selflink-stamp
+dependencies-stamp: $(SRC) | $(SELFLINK)
 	$(GO) get -d
 	touch $@
 

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -44,11 +44,16 @@ endif
 GO_VERSION ?= 1.4.1
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
-GOROOT     := $(CURDIR)/.build/go
 GOPATH     := $(CURDIR)/.build/gopath
 GOCC       ?= $(GOROOT)/bin/go
 GO         ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
 GOFMT      ?= $(GOROOT)/bin/gofmt
+
+ifeq ($(shell type go >/dev/null && go version | sed 's/.*go\([0-9.]*\).*/\1/'), $(GO_VERSION))
+	GOROOT := $(shell go env GOROOT)
+else
+	GOROOT := $(CURDIR)/.build/go$(GO_VERSION)
+endif
 
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN
@@ -61,14 +66,14 @@ SELFLINK ?= $(GOPATH)/src/$(ROOTPKG)
 
 default: $(BINARY)
 
-.build/$(GOPKG):
+$(GOCC):
+	@echo Go version $(GO_VERSION) required but not found in PATH.
+	@echo About to download and install go$(GO_VERSION) to $(GOROOT)
+	@echo Abort now if you want to manually install it system-wide instead.
+	@echo
+	@sleep 5
 	mkdir -p $(GOROOT)
-	mkdir -p $(GOPATH)
-	curl -o .build/$(GOPKG) -L $(GOURL)/$(GOPKG)
-
-$(GOCC): .build/$(GOPKG)
-	tar -C .build -xzf .build/$(GOPKG)
-	touch $@
+	curl -L $(GOURL)/$(GOPKG) | tar -C $(GOROOT) --strip 1 -xz
 
 selflink-stamp:
 	mkdir -p $(GOPATH)/src/github.com/prometheus


### PR DESCRIPTION
_Moved from https://github.com/prometheus/haproxy_exporter/pull/25_

In addtion to the changes in the previous PR:
- Additional help line is printed to explain where the installation will happen.
- custom GOROOT installations are now scoped by version to make sure an updated go installation won't be unpacked in the same directory of an older installation which might cause issues.

---

This change builds upon #21 and improves a few points:
- Use system go installation if available in the required version
- Download and unpack using a pipe. While this also makes the code more readable, the main reason is that the `$(GOCC)` must not longer have any dependencies to support a system go installation (having the dependency to download go first doesn't make sense in that case). When executing the curl and tar commands inside of one target anyway, we can also just skip the step to save it to disk entirely.
- Explains the fact that go needs to be downloaded and gives the user the chance to abort. This was mainly motivated by feedback received in IRC. People do not necessarily understand that we don't touch their system.
  
  ```
  00:34:44 < Furao> is there a way to prevent build process to mess with my golang installation?
  01:28:10 < grobie> the build process shouldn't touch anything outside of the working directory
  01:28:41 < Furao> I saw that after, I was just terrified to see it curl golang binaries
  01:28:46 < Furao> so I ctrl-c quickly
  ```
- Remove stamp. With order-only-prerequisites the goal of ensuring that a symlink exists (actually just the path in the filesystem) can be similarly achieved without the need to use a separate stamp file. Let's avoid such stamps wherever possible. They easily get out of sync and mostly get in the way of a clean dependency graph make needs to do its job.

The dependency-stamp would actually need to be checked in, I'm not sure people are aware of that? Otherwise adding/requiring dependencies will cause issues as local installations won't execute `go get` again. And if we use a checked in file, we can also just check a `Godeps/Godeps.json` instead :) I'll leave this for later though.
