### PR TITLE
Use conditionals for GOOS and GOARCH to allow cross-compiles

### DIFF
--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -41,8 +41,8 @@ VERSION ?= $(error VERSION not set in including Makefile)
 TARGET  ?= $(error TARGET not set in including Makefile)
 
 SRC    ?= $(shell find . -type f -name "*.go" ! -path "./.build/*")
-GOOS   := $(shell uname | tr A-Z a-z)
-GOARCH := $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
+GOOS   ?= $(shell uname | tr A-Z a-z)
+GOARCH ?= $(subst x86_64,amd64,$(patsubst i%86,386,$(shell uname -m)))
 
 ifeq ($(GOOS),darwin)
 	RELEASE_SUFFIX ?= -osx$(shell sw_vers -productVersion)


### PR DESCRIPTION
As discussed in prometheus/consul_exporter#1, this change make cross-compiling possible with the common Makefiles.

One thing I think needs to be thought through before merge, though: Because `$(ARCHIVE)` builds off `$(BINARY)`, which doesn't include suffix, running a `make archive` with a binary sitting there will use the binary regardless of whether it is the correct architecture. One answer to this would be to make BINARY be `$(TARGET).$(SUFFIX)`, and then maybe include a little convenience step in default that would cp the last binary compile to the unsuffixed name if necessary. 

Currently you have to make sure to do a `make clean` before each cross-compile.
