### PR TITLE
Explicitly set input to stdin when using tar.

### DIFF
--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -80,7 +80,7 @@ $(GOCC):
 	@echo
 	@sleep 5
 	mkdir -p $(GOROOT)
-	curl -L $(GOURL)/$(GOPKG) | tar -C $(GOROOT) --strip 1 -xz
+	curl -L $(GOURL)/$(GOPKG) | tar -C $(GOROOT) --strip 1 -xzf -
 
 $(SELFLINK):
 	mkdir -p $(dir $@)

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -97,7 +97,7 @@ $(BINARY): $(GOCC) $(SRC) dependencies-stamp Makefile Makefile.COMMON
 archive: $(ARCHIVE)
 
 $(ARCHIVE): $(BINARY)
-	tar --owner=root --group=root -czf $@ $<
+	tar -czf $@ $<
 
 .PHONY: tag
 tag:

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -79,8 +79,11 @@ $(GOCC):
 	@echo Abort now if you want to manually install it system-wide instead.
 	@echo
 	@sleep 5
-	mkdir -p $(GOROOT)
-	curl -L $(GOURL)/$(GOPKG) | tar -C $(GOROOT) --strip 1 -xzf -
+	mkdir -p .build
+	# The archive contains a single directory called 'go/'.
+	curl -L $(GOURL)/$(GOPKG) | tar -C .build -xzf -
+	rm -rf $(GOROOT)
+	mv .build/go $(GOROOT)
 
 $(SELFLINK):
 	mkdir -p $(dir $@)


### PR DESCRIPTION
GNU tar will misbehave if the TAPE environment variable is set.
Other versions of tar can have different defaults as well (e.g.
/dev/rst0 in OpenBSD tar).
