### PR TITLE
Respect GOARCH and GOOS on build

### DIFF
--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -54,13 +54,13 @@ GOPATH     := $(CURDIR)/.build/gopath
 ifeq ($(shell command -v "go" >/dev/null && go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/'), $(GO_VERSION))
 	GOCC   ?= $(shell command -v "go")
 	GOFMT  ?= $(shell command -v "gofmt")
-	GO     ?= GOPATH=$(GOPATH) $(GOCC)
 else
 	GOROOT ?= $(CURDIR)/.build/go$(GO_VERSION)
 	GOCC   ?= $(GOROOT)/bin/go
 	GOFMT  ?= $(GOROOT)/bin/gofmt
-	GO     ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
 endif
+
+GO ?= GOARCH=$(GOARCH) GOOS=$(GOOS) GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
 
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN


### PR DESCRIPTION
When cross-compiling for a different platform, GOARCH and GOOS actually
need to be used during `go build`. If the desired go version is already
present GOROOT will be empty, which works as expected.

With this change the following becomes possible:

```
for arch in 386 arm amd64; do
  rm -rf haproxy_exporter
  GOOS=linux GOARCH=$arch make archive
done
```

@brian-brazil @juliusv 
